### PR TITLE
feat: add git-url special meta property

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>yearn principles</title>
+    <meta name="git-url" content="https://github.com/banteg/yearn-principles" />
     <link rel="stylesheet" href="style.css"/>
     <link rel="apple-touch-icon" sizes="180x180" href="images/icon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="images/icon/favicon-32x32.png">


### PR DESCRIPTION
In order to be able to quickly get the github link of the repo from another website, add a `git-url` property to the meta tags. Will be used in a Yearn Registry website